### PR TITLE
refactor: make section 3 mobile friendly

### DIFF
--- a/src/app/(home)/section-2.tsx
+++ b/src/app/(home)/section-2.tsx
@@ -6,11 +6,12 @@ export const Section2 = () => {
     const { open } = useWeb3Modal();
     return (
         <Stack
+            component="section"
             sx={{
-                maxWidth: { xs: 'sm', lg: 'lg' },
-                flexDirection: { xs: 'column', lg: 'row' },
-                px: { xs: 2, md: 8 },
-                pt: { xs: 6, md: 10 },
+                maxWidth: { xs: 'md', md: 'lg' },
+                flexDirection: { xs: 'column', md: 'row' },
+                px: { xs: 2, sm: 8 },
+                pt: { xs: 6, sm: 10 },
                 mx: 'auto',
                 gap: 5
             }}

--- a/src/app/(home)/section-3.tsx
+++ b/src/app/(home)/section-3.tsx
@@ -14,8 +14,8 @@ export const Section3 = () => (
         component="section"
         sx={{
             py: 10,
-            pl: { xs: 2, md: 2, lg: 8 },
-            pr: { xs: 0, md: 2, lg: 8 },
+            pl: { xs: 2, sm: 8 },
+            pr: { xs: 0, md: 8 },
             maxWidth: { xs: 'md', md: 'lg' },
             justifyContent: 'center',
             alignItems: 'center',
@@ -40,7 +40,7 @@ export const Section3 = () => (
             <RankingsTable
                 values={mockData}
                 sx={{
-                    width: { xs: 540, sm: '100%' },
+                    width: { xs: 980 },
                     mr: { xs: 2, sm: 0 },
                     my: 4
                 }}

--- a/src/app/(home)/section-3.tsx
+++ b/src/app/(home)/section-3.tsx
@@ -41,7 +41,7 @@ export const Section3 = () => (
                 values={mockData}
                 sx={{
                     width: { xs: 980 },
-                    mr: { xs: 2, sm: 0 },
+                    mr: { xs: 8 },
                     my: 4
                 }}
             />
@@ -50,7 +50,7 @@ export const Section3 = () => (
         <RankingsTable
             values={mockData}
             sx={{
-                display: { xs: 'none', md: 'block', pr: 4 },
+                display: { xs: 'none', md: 'block' },
                 width: '100%',
                 my: 4
             }}

--- a/src/app/(home)/section-3.tsx
+++ b/src/app/(home)/section-3.tsx
@@ -1,65 +1,63 @@
-import { Box, Sheet, Table, Typography } from '@mui/joy';
+import { Box, Sheet, Stack, Table, Typography } from '@mui/joy';
+import { RankingsTable } from '@/shared/components/rankings-table';
+import { relative } from 'path';
 
 const mockData = [
-    { id: 1, name: 'Tiago', score: 50, points: 2000, nominations: 10 },
+    { id: 1, name: 'Tiago', score: 50, points: 2000, nominations: 10, highlight: true },
     { id: 2, name: 'Leal', score: 150, points: 4000, nominations: 70 },
     { id: 3, name: 'Filipe', score: 200, points: 10000, nominations: 50 },
     { id: 4, name: 'Pedro', score: 100, points: 8000, nominations: 30 }
 ];
 
 export const Section3 = () => (
-    <Box
+    <Stack
+        component="section"
         sx={{
-            // Temporary, hide section in mobile
-            display: 'flex',
-            padding: '80px 0 80px',
-
+            py: 10,
+            pl: { xs: 2, md: 2, lg: 8 },
+            pr: { xs: 0, md: 2, lg: 8 },
+            maxWidth: { xs: 'md', md: 'lg' },
             justifyContent: 'center',
-            alignItems: 'center'
+            alignItems: 'center',
+            mx: 'auto',
+            position: 'relative',
+            overflowX: 'hidden',
+            textAlign: 'center'
         }}
     >
-        <Box
+        <Typography
             sx={{
-                width: '1224px',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
-                alignItems: 'center',
-                gap: '40px'
+                color: 'common.white',
+                fontSize: { xs: 30, md: '40px' },
+                pr: { xs: 2, sm: 0 },
+                fontWeight: 'bold'
             }}
         >
-            <Typography sx={{ color: 'common.white', fontSize: '40px', fontWeight: 'bold' }}>
-                Layoff Leaderboard
-            </Typography>
+            Layoff Leaderboard
+        </Typography>
 
-            <Sheet variant="outlined" sx={{ width: '100%' }}>
-                <Table aria-label="basic table" sx={{ backgroundColor: 'common.white' }}>
-                    <thead>
-                        <tr>
-                            <th>Rank</th>
-                            <th>Name</th>
-                            <th>Builder Score</th>
-                            <th>BOSS Points</th>
-                            <th>Nominations Received</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {mockData.map(item => (
-                            <tr key={item.id}>
-                                <td>{item.id}</td>
-                                <td>{item.name}</td>
-                                <td>{item.score}</td>
-                                <td>{item.points}</td>
-                                <td>{item.nominations}</td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </Table>
-            </Sheet>
+        <Stack sx={{ width: '100%', overflowX: 'scroll', display: { md: 'none' } }}>
+            <RankingsTable
+                values={mockData}
+                sx={{
+                    width: { xs: 540, sm: '100%' },
+                    mr: { xs: 2, sm: 0 },
+                    my: 4
+                }}
+            />
+        </Stack>
 
-            <Typography sx={{ color: 'common.white', fontSize: '14px' }}>
-                Last update on May 21st, 4pm UTC. Next update on May 30, 4pm UTC
-            </Typography>
-        </Box>
-    </Box>
+        <RankingsTable
+            values={mockData}
+            sx={{
+                display: { xs: 'none', md: 'block', pr: 4 },
+                width: '100%',
+                my: 4
+            }}
+        />
+
+        <Typography sx={{ color: 'common.white', fontSize: '14px', pr: { xs: 2, md: 0 } }}>
+            Last update on May 21st, 4pm UTC. Next update on May 30, 4pm UTC
+        </Typography>
+    </Stack>
 );

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -49,6 +49,7 @@ export const theme = extendTheme({
                 root: ({ ownerState, theme }) => ({
                     ...(ownerState.variant === 'outlined' && {
                         backgroundColor: theme.vars.palette.common.white,
+                        boxSizing: 'border-box',
                         boxShadow: `12px 12px 0px 0px ${theme.vars.palette.common.black}`,
                         border: `4px solid ${theme.vars.palette.common.black}`
                     })

--- a/src/shared/components/rankings-table.tsx
+++ b/src/shared/components/rankings-table.tsx
@@ -16,6 +16,7 @@ export const RankingsTable = ({ values, variant = 'outlined', ...props }: Rankin
         <Table
             sx={{
                 backgroundColor: 'common.white',
+                tr: { textAlign: 'left' },
                 '& tr.highlight': { color: 'primary.500' }
             }}
         >
@@ -25,7 +26,7 @@ export const RankingsTable = ({ values, variant = 'outlined', ...props }: Rankin
                     <th>Name</th>
                     <th>Builder Score</th>
                     <th>BOSS Points</th>
-                    <th>Nominations Received</th>
+                    <th style={{ width: 164 }}>Nominations Received</th>
                 </tr>
             </thead>
             <tbody>

--- a/src/shared/components/rankings-table.tsx
+++ b/src/shared/components/rankings-table.tsx
@@ -1,0 +1,44 @@
+import { Sheet, SheetProps, Table } from '@mui/joy';
+
+export type RankingsTableProps = {
+    values: Array<{
+        id: number;
+        name: string;
+        score: number;
+        points: number;
+        nominations: number;
+        highlight?: boolean;
+    }>;
+} & SheetProps;
+
+export const RankingsTable = ({ values, variant = 'outlined', ...props }: RankingsTableProps) => (
+    <Sheet {...props} variant={variant} sx={props.sx}>
+        <Table
+            sx={{
+                backgroundColor: 'common.white',
+                '& tr.highlight': { color: 'primary.500' }
+            }}
+        >
+            <thead>
+                <tr>
+                    <th>Rank</th>
+                    <th>Name</th>
+                    <th>Builder Score</th>
+                    <th>BOSS Points</th>
+                    <th>Nominations Received</th>
+                </tr>
+            </thead>
+            <tbody>
+                {values.map(item => (
+                    <tr key={item.id} className={item.highlight ? 'highlight' : ''}>
+                        <td>{item.id}</td>
+                        <td>{item.name}</td>
+                        <td>{item.score}</td>
+                        <td>{item.points}</td>
+                        <td>{item.nominations}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </Table>
+    </Sheet>
+);


### PR DESCRIPTION
- Adds section 3 as a component
- Adds border boxing rule to sheet. this makes the alignment of this component predictable
- Adds 2 tables, one for mobile one for desktop. Since we are only rendering 5 rows, performance shouldnt be a factor, and thsi saves a lot of headaches. 