### PR TITLE
feat: fix connect wallet colours, add typecheck, add links

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     reactStrictMode: true,
+    experimental: {
+        typedRoutes: true,
+    },
     i18n: {
         locales: ['en-US', 'zh-CN'],
         defaultLocale: 'en-US'

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     reactStrictMode: true,
-    experimental: {
-        typedRoutes: true,
-    },
     i18n: {
         locales: ['en-US', 'zh-CN'],
         defaultLocale: 'en-US'

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     reactStrictMode: true,
+    experimental: {
+        typedRoutes: true
+    },
     i18n: {
         locales: ['en-US', 'zh-CN'],
         defaultLocale: 'en-US'

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "start": "next start",
         "lint": "next lint",
         "prettier": "prettier --write .",
+        "types": "tsc --noEmit",
         "supabase-types": "supabase gen types typescript --project-id \"$SUPABASE_BOSS_PROJECT\" --schema public > src/db/database.types.ts"
     },
     "dependencies": {

--- a/src/app/bossenomics/section-2.tsx
+++ b/src/app/bossenomics/section-2.tsx
@@ -1,6 +1,6 @@
 import { Sheet, Stack, Typography, Box } from '@mui/joy';
-import DESKTOP_GRAPH from "../../../public/images/bossenomics-graph.png"
-import MOBILE_GRAPH from "../../../public/images/bossenomics-graph-mobile.png"
+import DESKTOP_GRAPH from '../../../public/images/bossenomics-graph.png';
+import MOBILE_GRAPH from '../../../public/images/bossenomics-graph-mobile.png';
 import Image from 'next/image';
 
 export const Section2 = () => {
@@ -8,7 +8,7 @@ export const Section2 = () => {
         <Stack
             component="section"
             sx={{
-                mx: "auto",
+                mx: 'auto',
                 maxWidth: { xs: 'sm', md: 'lg' },
                 px: { xs: 2, sm: 8 },
                 py: 5,
@@ -17,7 +17,6 @@ export const Section2 = () => {
         >
             <Stack
                 sx={{
-
                     gap: 2
                 }}
             >
@@ -49,10 +48,7 @@ export const Section2 = () => {
                 </Typography>
             </Stack>
 
-            <Sheet
-                variant='outlined'
-                sx={{ width: "100%" }}
-            >
+            <Sheet variant="outlined" sx={{ width: '100%' }}>
                 <Stack sx={{ py: { xs: 5, md: 5 }, px: { xs: 5, md: 20 } }}>
                     <Box sx={{ display: { xs: 'none', md: 'block' } }}>
                         <Image src={DESKTOP_GRAPH} alt="graph" style={{ width: '100%', height: 'auto' }} />

--- a/src/shared/components/connect-wallet-button.tsx
+++ b/src/shared/components/connect-wallet-button.tsx
@@ -14,8 +14,12 @@ export const ConnectWalletButton = ({ hideIfConnected }: { hideIfConnected?: boo
         <NoSsr fallback={<Button disabled>Connect Wallet</Button>}>
             <Box
                 sx={{
-                    '& > w3m-button': { height: 40, '--wui-color-accent-100': t => t.vars.palette.common.white },
-                    '& w3m-button button': { backgroundColor: 'red', height: 40 }
+                    '& > w3m-button': { 
+                        height: 40, 
+                        '--wui-color-accent-100': t => t.vars.palette.neutral.solidBg,
+                        '--wui-color-inverse-100': t => t.vars.palette.neutral.solidColor, 
+                        '--wui-color-accent-090': t => t.vars.palette.neutral.solidHoverBg,
+                    },
                 }}
             >
                 <w3m-button />

--- a/src/shared/components/connect-wallet-button.tsx
+++ b/src/shared/components/connect-wallet-button.tsx
@@ -14,12 +14,12 @@ export const ConnectWalletButton = ({ hideIfConnected }: { hideIfConnected?: boo
         <NoSsr fallback={<Button disabled>Connect Wallet</Button>}>
             <Box
                 sx={{
-                    '& > w3m-button': { 
-                        height: 40, 
+                    '& > w3m-button': {
+                        height: 40,
                         '--wui-color-accent-100': t => t.vars.palette.neutral.solidBg,
-                        '--wui-color-inverse-100': t => t.vars.palette.neutral.solidColor, 
-                        '--wui-color-accent-090': t => t.vars.palette.neutral.solidHoverBg,
-                    },
+                        '--wui-color-inverse-100': t => t.vars.palette.neutral.solidColor,
+                        '--wui-color-accent-090': t => t.vars.palette.neutral.solidHoverBg
+                    }
                 }}
             >
                 <w3m-button />

--- a/src/shared/theme/theme-link.tsx
+++ b/src/shared/theme/theme-link.tsx
@@ -1,10 +1,10 @@
-import { default as NextLink, LinkProps } from "next/link";
-import { forwardRef } from "react";
+import { default as NextLink } from 'next/link';
+import { ComponentProps, forwardRef } from 'react';
 
 /**
  * Replaces the Joy UI Link with a Next.js Link, enabling all black magic
  * Next Does when you hover a link.
  */
-export const ThemeLink = forwardRef<HTMLAnchorElement, LinkProps>(function Link(props, ref) {
+export const ThemeLink = forwardRef<HTMLAnchorElement, ComponentProps<typeof NextLink>>(function Link(props, ref) {
     return <NextLink ref={ref} {...props} />;
 });

--- a/src/shared/theme/theme-link.tsx
+++ b/src/shared/theme/theme-link.tsx
@@ -1,0 +1,10 @@
+import { default as NextLink, LinkProps } from "next/link";
+import { forwardRef } from "react";
+
+/**
+ * Replaces the Joy UI Link with a Next.js Link, enabling all black magic
+ * Next Does when you hover a link.
+ */
+export const ThemeLink = forwardRef<HTMLAnchorElement, LinkProps>(function Link(props, ref) {
+    return <NextLink ref={ref} {...props} />;
+});

--- a/src/shared/theme/theme.ts
+++ b/src/shared/theme/theme.ts
@@ -39,8 +39,8 @@ export const theme = extendTheme({
     components: {
         JoyLink: {
             defaultProps: {
-                component: ThemeLink,
-            },
+                component: ThemeLink
+            }
         },
         JoyButton: {
             styleOverrides: {
@@ -48,7 +48,7 @@ export const theme = extendTheme({
                     height: 40,
                     borderRadius: '0'
                 }
-            },
+            }
         },
         JoySheet: {
             styleOverrides: {

--- a/src/shared/theme/theme.ts
+++ b/src/shared/theme/theme.ts
@@ -1,5 +1,6 @@
 'use client';
 import { extendTheme } from '@mui/joy/styles';
+import { ThemeLink } from './theme-link';
 
 const colors = {
     blue: '#0142F5',
@@ -36,13 +37,18 @@ export const theme = extendTheme({
     },
     typography: {},
     components: {
+        JoyLink: {
+            defaultProps: {
+                component: ThemeLink,
+            },
+        },
         JoyButton: {
             styleOverrides: {
                 root: {
                     height: 40,
                     borderRadius: '0'
                 }
-            }
+            },
         },
         JoySheet: {
             styleOverrides: {


### PR DESCRIPTION
- Add Next Links as implementation for mui links (this allows next js to make its prelaod magic) 
- Adds type check command `yarn types`. 
- Changes the colors of the button only. Does not affect the modal. 

<img width="1154" alt="image" src="https://github.com/francisco-leal/boss-token/assets/9625304/7b65ed77-1057-459a-8361-4a997906c9e0">
<img width="800" alt="image" src="https://github.com/francisco-leal/boss-token/assets/9625304/36103b36-8dab-48c3-ac34-63df11c49f80">

