### PR TITLE
fix: keep connect button vertically aligned

### DIFF
--- a/src/shared/components/connect-wallet-button.tsx
+++ b/src/shared/components/connect-wallet-button.tsx
@@ -15,7 +15,7 @@ export const ConnectWalletButton = ({ hideIfConnected, ...props }: ConnectWallet
     if (hideIfConnected && address) return null;
 
     return (
-        <NoSsr fallback={<Button disabled>Connect Wallet</Button>}>
+        <NoSsr fallback={<Button disabled>Connect&nbsp;Wallet</Button>}>
             <Stack
                 {...props}
                 sx={{

--- a/src/shared/components/header.tsx
+++ b/src/shared/components/header.tsx
@@ -59,7 +59,7 @@ export const Header = () => {
                     </Stack>
                 </Stack>
 
-                <Stack direction={'row'} flex={1} justifyContent={'flex-end'}>
+                <Stack direction={'row'} flex={1} justifyContent={'flex-end'} alignItems={"center"}>
                     {!drawer.isOpen && (
                         <ConnectWalletButton sx={{ flex: { xs: 1, md: 'initial', justifyContent: 'center' } }} />
                     )}


### PR DESCRIPTION
- Prevents word wrap of placeholder button 
- Aligns connect button vertically with the dropdown button