### PR TITLE
fix: apply consistent size to memo page

### DIFF
--- a/src/app/memo/page.tsx
+++ b/src/app/memo/page.tsx
@@ -5,6 +5,7 @@ import { Header } from "@/shared/components/header";
 import { Footer } from "@/shared/components/footer";
 import Signature from "../../../public/images/signature.png";
 import Image from "next/image";
+import { HeroSection } from "@/shared/components/hero-section";
 
 const content = [
   "Dear builder,",
@@ -21,24 +22,17 @@ const content = [
 
 export default function Memo() {
   return (
-    <main>
+    <>
       <Header />
-
-      <Stack sx={{ alignItems: "center" }}>
-        <Stack
-          component="section"
-          sx={{
-            maxWidth: { md: "lg" },
-            py: 10,
-            px: { xs: 2, md: 0 },
-          }}
-        >
+      <Stack component="main">
+        <HeroSection>
           <Sheet
             variant="outlined"
             sx={{
               flex: 1,
               display: "flex",
               flexDirection: "column",
+              textAlign: "left",
               py: { xs: 5, md: 15 },
               px: { xs: 2, md: 21 },
               gap: 5,
@@ -62,10 +56,9 @@ export default function Memo() {
               <Image src={Signature} alt="signature" />
             </Stack>
           </Sheet>
-        </Stack>
+        </HeroSection>
       </Stack>
-
       <Footer />
-    </main>
+    </>
   );
 }


### PR DESCRIPTION
- Align contents of memo page with each other and the other pages.

Before: 

<img width="1470" alt="image" src="https://github.com/francisco-leal/boss-token/assets/9625304/8cfba980-07d0-4031-94bd-9f7e2521468f">

After: 

<img width="1470" alt="image" src="https://github.com/francisco-leal/boss-token/assets/9625304/d313b380-3f5b-4687-9c9d-069d7e6ae3ca">
