### PR TITLE
feat: prevent error when nominating new user

### DIFF
--- a/src/app/_api/authentication.ts
+++ b/src/app/_api/authentication.ts
@@ -3,8 +3,7 @@
 import { cookies } from "next/headers";
 import { sealData } from "iron-session";
 import { SiweMessage, generateNonce } from "siwe";
-import { createNewUser } from "./create-new-user";
-import { getOrCreateUser, getUser } from "./get-user";
+import { getOrCreateUser } from "./get-user";
 
 const sessionPassword = process.env.SESSION_PASSWORD as string;
 if (!sessionPassword) throw new Error("SESSION_PASSWORD is not set");

--- a/src/app/_api/authentication.ts
+++ b/src/app/_api/authentication.ts
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 import { sealData } from "iron-session";
 import { SiweMessage, generateNonce } from "siwe";
 import { createNewUser } from "./create-new-user";
-import { getUser } from "./get-user";
+import { getOrCreateUser, getUser } from "./get-user";
 
 const sessionPassword = process.env.SESSION_PASSWORD as string;
 if (!sessionPassword) throw new Error("SESSION_PASSWORD is not set");
@@ -33,7 +33,7 @@ export const connectUser = async ({
 
   if (error) throw new Error("Error verifying message");
 
-  if (!(await getUser(address))) await createNewUser(address);
+  await getOrCreateUser(address);
 
   const sessionUser = {
     wallet: address,

--- a/src/app/_api/create-new-nomination.ts
+++ b/src/app/_api/create-new-nomination.ts
@@ -4,17 +4,10 @@ import { revalidatePath, revalidateTag } from "next/cache";
 import { DateTime, Interval } from "luxon";
 import { supabase } from "@/db";
 import { BadRequestError } from "@/shared/utils/error";
-import { createNewUser } from "./create-new-user";
 import { getNomination, getNominationsFromWallet } from "./get-nomination";
-import { getCurrentUser, getUser } from "./get-user";
+import { getCurrentUser, getOrCreateUser, getUser } from "./get-user";
 import { CacheKey } from "./helpers/cache-keys";
 import { JobTypes } from "./helpers/job-types";
-
-export const getNominatedUser = async (wallet: string) => {
-  const existingUser = await getUser(wallet);
-  if (existingUser) return existingUser;
-  return await createNewUser(wallet);
-};
 
 export const getTodaysNominations = async (wallet: string) => {
   const nominations = await getNominationsFromWallet(wallet);
@@ -71,7 +64,7 @@ export const hasExceededNominationsToday = async (nominatorWallet: string) => {
 
 export async function createNewNomination(walletToNominate: string) {
   const nominatorUser = await getCurrentUser();
-  const nominatedUser = await getNominatedUser(walletToNominate);
+  const nominatedUser = await getOrCreateUser(walletToNominate);
   const nominatorWallet = nominatorUser?.wallet?.toLocaleLowerCase();
   const nominatedWallet = nominatedUser?.wallet?.toLocaleLowerCase();
 

--- a/src/app/_api/create-new-user.ts
+++ b/src/app/_api/create-new-user.ts
@@ -100,9 +100,9 @@ export async function createNewUser(wallet_address: string) {
     })
     .throwOnError();
 
+  revalidateTag(`user_${wallet_address}` satisfies CacheKey);
   const finalUser = await getUser(wallet_address);
   if (!finalUser) throw new Error("User creation failed");
 
-  revalidateTag(`user_${wallet_address}` satisfies CacheKey);
   return await finalUser;
 }

--- a/src/app/_api/get-user.ts
+++ b/src/app/_api/get-user.ts
@@ -3,6 +3,7 @@
 import { unstable_cache } from "next/cache";
 import { supabase } from "@/db";
 import { getSession } from "@/services/authentication/cookie-session";
+import { createNewUser } from "./create-new-user";
 import { CACHE_5_MINUTES, CacheKey } from "./helpers/cache-keys";
 
 export type User = {
@@ -35,6 +36,10 @@ export const getUser = async (wallet: string): Promise<User | null> => {
       { revalidate: CACHE_5_MINUTES },
     )
   )();
+};
+
+export const getOrCreateUser = async (wallet: string): Promise<User> => {
+  return (await getUser(wallet)) ?? (await createNewUser(wallet));
 };
 
 export const getCurrentUser = async (): Promise<User | null> => {

--- a/src/app/_api/search-builders.ts
+++ b/src/app/_api/search-builders.ts
@@ -35,11 +35,13 @@ const filterFarcasterAddress = (
   return f.length === 1 ? f[0] : userAddress;
 };
 
+const removeUserWithoutWallet = (v: BuilderProfile) => !!v.address;
+
 const removeDuplicateBuilders = (
   v: BuilderProfile,
   i: number,
   a: BuilderProfile[],
-) => v.address && a.findIndex((t) => t.address === v.address) === i;
+) => a.findIndex((t) => t.address === v.address) === i;
 
 export const searchBuilders = unstable_cache(
   async (query: string) => {
@@ -110,9 +112,9 @@ export const searchBuilders = unstable_cache(
       }),
     ]);
 
-    return [...talentProtocolResults, ...farcasterResults].filter(
-      removeDuplicateBuilders,
-    );
+    return [...talentProtocolResults, ...farcasterResults]
+      .filter(removeUserWithoutWallet)
+      .filter(removeDuplicateBuilders);
   },
   ["search_builders"] satisfies CacheKey[],
   { revalidate: CACHE_5_MINUTES },

--- a/src/app/_components/@nominateBuilder/component.tsx
+++ b/src/app/_components/@nominateBuilder/component.tsx
@@ -154,7 +154,9 @@ export const NominateBuilderComponent: FunctionComponent<
                 textColor="common.black"
                 sx={{ ml: "auto", mr: 0.5 }}
               >
-                {isDisplayingUserValues ? currentUserBossDailyBudget?.toFixed(2) : "--"}
+                {isDisplayingUserValues
+                  ? currentUserBossDailyBudget?.toFixed(2)
+                  : "--"}
               </Typography>
               <LogoShort color={isPrimaryColor ? "primary" : "neutral"} />
             </Stack>
@@ -166,7 +168,9 @@ export const NominateBuilderComponent: FunctionComponent<
                 textColor="common.black"
                 sx={{ ml: "auto", mr: 0.5 }}
               >
-                {isDisplayingUserValues ? currentUserBossPointsToBeGiven?.toFixed(2) : "--"}
+                {isDisplayingUserValues
+                  ? currentUserBossPointsToBeGiven?.toFixed(2)
+                  : "--"}
               </Typography>
               <LogoShort color={isPrimaryColor ? "primary" : "neutral"} />
             </Stack>
@@ -194,7 +198,9 @@ export const NominateBuilderComponent: FunctionComponent<
                 textColor="common.black"
                 sx={{ ml: "auto", mr: 0.5 }}
               >
-                {isDisplayingUserValues ? currentUserBossTotalPoints?.toFixed(2) : "--"}
+                {isDisplayingUserValues
+                  ? currentUserBossTotalPoints?.toFixed(2)
+                  : "--"}
               </Typography>
               <LogoShort color={isPrimaryColor ? "primary" : "neutral"} />
             </Stack>


### PR DESCRIPTION
- Adds `getOrCreateUser` which should be used almost always instead of `createUser`since `createUser` crashes if called for an existing user. 
- Fixes `createUser` cache invalidation 
- Removes "no wallets" from search