### PR TITLE
fix: last minute fixes

### DIFF
--- a/src/app/_api/create-new-nomination.ts
+++ b/src/app/_api/create-new-nomination.ts
@@ -81,8 +81,8 @@ export async function createNewNomination(walletToNominate: string) {
   if (await isDuplicateNomination(nominatorWallet, nominatedWallet)) {
     throw new BadRequestError("You already nominated this builder before!");
   }
-  if (await hasExceededNominationsToday(nominatedWallet)) {
-    throw new BadRequestError("You have already nominated a builder today!");
+  if (await hasExceededNominationsToday(nominatorWallet)) {
+    throw new BadRequestError("You have already nominated 3 builders today!");
   }
   if (await isUpdatingLeaderboard()) {
     throw new BadRequestError(

--- a/src/app/_components/@nominateBuilder/component.tsx
+++ b/src/app/_components/@nominateBuilder/component.tsx
@@ -93,7 +93,7 @@ export const NominateBuilderComponent: FunctionComponent<
 
   useEffect(() => {
     if (state !== "INVALID_NOMINATION") return;
-    const interval = setInterval(() => forcePathRevalidation(pathname), 5000);
+    const interval = setInterval(() => forcePathRevalidation(pathname), 10_000);
     return () => clearInterval(interval);
   }, [state, pathname]);
 
@@ -102,8 +102,12 @@ export const NominateBuilderComponent: FunctionComponent<
       <ModalOverflow>
         <ModalDialog
           variant="solid"
-          sx={{ width: "100%", maxWidth: "sm", color: "neutral.500" }}
           layout={isMediumScreen ? "center" : "fullscreen"}
+          sx={{ 
+            width: "100%",
+             maxWidth: { xs: "lg", md:"sm"}, 
+             color: "neutral.500" 
+          }}
         >
           <ModalClose variant="plain" />
 


### PR DESCRIPTION
3 unrelated fixes:

- Reduce the poke time for invalid state to 10 seconds. This poke primarily exists for people who are hanging around the update job, and day changeover to nominate ASAP
- Fix the modal size so its always fullscreen before it switches to a modal 
- Fix check on nominations <3 per day